### PR TITLE
Fix syntax error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ npm install --save map-expire
 ```javascript
 
 const Cache = require('map-expire');
-const new Cache()
+const cache = new Cache()
 
 cache.set(key, value, duration)
 
-var value = cache.get(key)
+const value = cache.get(key)
 
 ```
 


### PR DESCRIPTION
`const new Cache()` did not compile. I have also updated `value` from `var` to `const` for consistency.