### PR TITLE
Fix bug "cannot read value of undefined" when under heavy load

### DIFF
--- a/MapExpire.js
+++ b/MapExpire.js
@@ -46,7 +46,8 @@ class MapExpire extends Map {
   }
 
   delete(key){
-    this.events.emit('delete', key, super.get(key).value)
+    const superKey = super.get(key)
+    if (superKey) this.events.emit('delete', key, superKey.value)
     super.delete(key)
   }
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "eslint": "^7.17.0",
-    "mocha": "^8.2.1"
+    "mocha": "^8.2.1",
+    "sinon": "^9.2.4"
   }
 }

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 const cache = require('./index')
 const MapExpire = require('./MapExpire')
 const assert = require('assert')
+var sinon = require('sinon')
 
 describe('Map Expire', function(){
   describe('Method Test', ()=>{
@@ -81,6 +82,18 @@ describe('Map Expire', function(){
       assert.strictEqual(cache.size, cache.capacity)
       for (let n = test - cache.capacity; n < test; n++)
         assert.strictEqual(cache.get(n), n * n)
+      done()
+    })
+    it('should handle items deletion while new cache items exeeding capacity are being set quicker than ttl', done => {
+      var clock = sinon.useFakeTimers()
+      const map = new MapExpire([], {
+        capacity: 10,
+      })
+      map.on('delete', (_, value) => {
+        assert.strictEqual(value, 'value')
+      })
+      Array.from({length: 11}).map((_, i) => i).map(key => map.set(key, 'value', 100))
+      clock.tick(100)
       done()
     })
   })


### PR DESCRIPTION
There is a scenario with a size limited cache and new items that get cached quicker than the ttl of the overflowed items.

In that case `super.get(key)` will be `undefined` for those overflowed items, thus `super.get(key).value` will thrown an error